### PR TITLE
[noisy-error] Fix clause that was never used anyway

### DIFF
--- a/src/geodata2_format.erl
+++ b/src/geodata2_format.erl
@@ -125,7 +125,7 @@ lookup(#meta{ip_version = V} = Meta,
 lookup(#meta{ip_version = 6, v4_start = V4Start} = Meta,
        Data,
        Bits,
-       6) -> %%lookup v4 in v6 db
+       4) -> %%lookup v4 in v6 db
     lookup_pos(Meta, Data, Bits, V4Start);
 %% @TODO [RTI-8302] This one could be removed after the IPv4+IPv6 MMDB is definitely used
 lookup(_,


### PR DESCRIPTION
This clause was never matching since the previous clause always matched for this particular situation, but the compiler and dialyzer are not smart enough to notice it.
Anyway, the idea was to be able to look up ipv4 addresses in an ipv6 database. So, I implemented just that.