### PR TITLE
RTI-14121: Remove support for ipv4 only databases

### DIFF
--- a/src/geodata2.erl
+++ b/src/geodata2.erl
@@ -8,8 +8,7 @@
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2]).
 %% API
--export([lookup/1, lookup_iptodomain/1, start/0, start_link/1, stop/0, get_env/2, id/1,
-         is_ipv6_mmdb/0]).
+-export([lookup/1, lookup_iptodomain/1, start/0, start_link/1, stop/0, get_env/2, id/1]).
 
 -define(GEODATA2_STATE_TID, geodata2_state).
 -define(GEODATA2_DOMAIN_TID, geodata2_domain).
@@ -71,12 +70,6 @@ new(ConfigName, Ets) ->
                                 RawData
                         end,
                     {ok, Meta} = geodata2_format:meta(Data),
-                    case ConfigName of
-                        dbfile ->
-                            set_is_ipv6_mmdb(Meta);
-                        _ ->
-                            ok
-                    end,
                     ets:insert(Ets, {data, Data}),
                     ets:insert(Ets, {meta, Meta}),
                     ok;
@@ -132,11 +125,3 @@ id(X) ->
 
 is_compressed(Filename) ->
     <<".gz">> == iolist_to_binary(filename:extension(Filename)).
-
-%% @TODO [RTI-8302] This one could be removed after the IPv4+IPv6 MMDB is definitely used
-is_ipv6_mmdb() ->
-    application:get_env(geodata2, ipv6, false).
-
-%% @TODO [RTI-8302] This one could be removed after the IPv4+IPv6 MMDB is definitely used
-set_is_ipv6_mmdb(Meta) ->
-    application:set_env(geodata2, ipv6, geodata2_format:is_ipv6(Meta)).

--- a/src/geodata2_format.erl
+++ b/src/geodata2_format.erl
@@ -33,7 +33,7 @@
 -define(EX_GEO_FLOAT, 15).
 
 %% API
--export([parse/2, unpack/2, meta/1, lookup/4, is_ipv6/1]).
+-export([parse/2, unpack/2, meta/1, lookup/4]).
 
 meta(Data) ->
     Size = byte_size(Data),
@@ -111,12 +111,6 @@ v4_tree_start(Data, #meta{ip_version = 6} = Meta) ->
     {error, {partial, Pos}} = lookup(Meta, Data, Bits, 6),
     Pos.
 
-%% @TODO [RTI-8302] This one could be removed after the IPv4+IPv6 MMDB is definitely used
-is_ipv6(#meta{ip_version = 6}) ->
-    true;
-is_ipv6(_) ->
-    false.
-
 lookup(#meta{ip_version = V} = Meta,
        Data,
        Bits,
@@ -126,13 +120,7 @@ lookup(#meta{ip_version = 6, v4_start = V4Start} = Meta,
        Data,
        Bits,
        4) -> %%lookup v4 in v6 db
-    lookup_pos(Meta, Data, Bits, V4Start);
-%% @TODO [RTI-8302] This one could be removed after the IPv4+IPv6 MMDB is definitely used
-lookup(_,
-       _,
-       _,
-       _) -> %%lookup v6 in v4 db
-    {error, v4db}.
+    lookup_pos(Meta, Data, Bits, V4Start).
 
 %% can't happen in the real db, gets used for lookup of v4 tree start
 lookup_pos(#meta{node_count = NodeCount}, _, <<>>, Pos) when Pos < NodeCount ->

--- a/test/geodata_SUITE.erl
+++ b/test/geodata_SUITE.erl
@@ -10,8 +10,7 @@
 %% Export here the tests
 -export([lookup/1, domain_lookup/1, no_file_is_found/1, domain_file_not_found/1,
          domain_lookup_weird_ip/1, domain_lookup_not_found/1, domain_lookup_format_not_allowed/1,
-         domain_lookup_ip_in_v6_not_allowed/1, domain_lookup_invalid_ip_with_port/1,
-         domain_not_in_config_should_start/1]).
+         domain_lookup_invalid_ip_with_port/1, domain_not_in_config_should_start/1]).
 
 %%%===================================================================
 %%% CT callbacks
@@ -24,7 +23,6 @@ all() ->
      domain_lookup_weird_ip,
      domain_lookup_not_found,
      domain_lookup_format_not_allowed,
-     domain_lookup_ip_in_v6_not_allowed,
      domain_lookup_invalid_ip_with_port,
      domain_not_in_config_should_start].
 
@@ -80,12 +78,6 @@ domain_lookup_weird_ip(_) ->
 
 domain_lookup_format_not_allowed(_) ->
     ?assertEqual({error, format}, geodata2:lookup_iptodomain(atom_not_allowed_format_error)),
-    ok.
-
-%% Test a domain lookup with weird input
-domain_lookup_ip_in_v6_not_allowed(_) ->
-    ?assertEqual({error, v4db},
-                 geodata2:lookup_iptodomain("2001:0db8:85a3:0000:0000:8a2e:0370:7334")),
     ok.
 
 domain_lookup_not_found(_) ->


### PR DESCRIPTION
[Test deployed in boodah](https://app.datadoghq.com/dashboard/4bm-ca6-4kn/rtb-diagnostic-board?tpl_var_control=rti-14121-geodata2-ipv6-ctrl&tpl_var_exchange%5B0%5D=index&tpl_var_exchange%5B1%5D=adx&tpl_var_region%5B0%5D=us-east-1&tpl_var_target=rti-14121-geodata2-ipv6&from_ts=1679481609976&to_ts=1679482395829&live=false)