### PR TITLE
[RTI-15687] Don't crash if an IPv6 DB doesn't map IPv4 addresses

### DIFF
--- a/src/geodata2_format.erl
+++ b/src/geodata2_format.erl
@@ -108,8 +108,13 @@ v4_tree_start(_Data, #meta{ip_version = 4}) ->
     0;
 v4_tree_start(Data, #meta{ip_version = 6} = Meta) ->
     Bits = <<0:80, 16#FFFF:16>>,
-    {error, {partial, Pos}} = lookup(Meta, Data, Bits, 6),
-    Pos.
+    case lookup(Meta, Data, Bits, 6) of
+        {error, {partial, Pos}} ->
+            Pos;
+        not_found ->
+            %% this only happens if the IPv6 database doesn't map any IPv4 addresses
+            none
+    end.
 
 lookup(#meta{ip_version = V} = Meta,
        Data,


### PR DESCRIPTION
`geodata2` is implemented so that when being started in the supervision tree, it will first try to parse two files set in the `geodata2` app config (with the second being optional). This second file got recently updated from being an IPv4 DB to an IPv6 DB, and the library expects these to have a `v4_tree_start` (a root index to be used as the starting point for lookups) but this is not necessarily true, and is definitely not the case if the IPv6 DB file does not contain any mappings for IPv4 addresses.

This PR updates `geodata2` so that when trying to find the `v4_tree_start` for an IPv6-related file, it knows not to crash if it does not find one.