### PR TITLE
[RTI-15693] Handle IPv6 tree start when its first lookup failed

### DIFF
--- a/src/geodata2_format.erl
+++ b/src/geodata2_format.erl
@@ -39,7 +39,7 @@ meta(Data) ->
     Size = byte_size(Data),
     {ok, RawMeta} = read_meta(Data, Size - 14),
     %%'undefined' is safe as there are no pointers in meta
-    {ok, Meta} = geodata2_format:unpack(undefined, RawMeta),
+    {ok, Meta} = unpack(undefined, RawMeta),
     make_meta(Data, Meta).
 
 make_meta(Data, Meta) ->
@@ -112,8 +112,13 @@ v4_tree_start(Data, #meta{ip_version = 6} = Meta) ->
         {error, {partial, Pos}} ->
             Pos;
         not_found ->
-            %% this only happens if the IPv6 database doesn't map any IPv4 addresses
-            none
+            case lookup(Meta, Data, <<0:96>>, 6) of
+                {error, {partial, Pos}} ->
+                    Pos;
+                %% this only happens if the IPv6 database doesn't map any IPv4 addresses
+                not_found ->
+                    0
+            end
     end.
 
 lookup(#meta{ip_version = V} = Meta,


### PR DESCRIPTION
**Jira ticket:** https://adroll.atlassian.net/browse/RTI-15693
Kind of a follow-up to https://github.com/SemanticSugar/geodata2/pull/51, but more thoroughly tested and looked into.

`geodata2` had issues with the new ip-to-domain file that we will be consuming, once it starts being IPv6 based, because when initially building the tree from the MaxMind file, it was failing to find an initial position from which consequent lookups in the tree should be started.

This PR makes it so that if this first lookup (that is done only once, when building the tree from the file data) fails, we first try finding the initial position by doing a second lookup with a different address, inspired by what another MMDB reader Erlang library is doing (see https://github.com/g-andrade/locus/commit/75e38f3dd09981730d09c18d3d2b70bf28345be1 for more), which I was able to confirm that it parses the IPv6 file properly, and that consequent IP lookups produced the expected results, before finally picking `0` as a failsafe starting position, if the second lookup also fails.

Because `geodata2` is used by some systems of ours, I have test-deployed both dyno (the one that was erroring like crazy last time I tried to fix the issue) and boodah; see the links below:
- dyno
  - [logs](https://app.datadoghq.com/logs?query=service%3Adyno%20version%3Abb5a7797491461fa56bed0945bcf053137d3dabd&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1716195240000&to_ts=1716201360000&live=false)
  - [dashboard](https://app.datadoghq.com/dashboard/nev-xcw-vmw/dyno-release-staging?fromUser=true&refresh_mode=paused&tpl_var_exchange=staging&tpl_var_region=us-west-2&tpl_var_version%5B0%5D=bb5a7797491461fa56bed0945bcf053137d3dabd&view=spans&from_ts=1716195240000&to_ts=1716201360000&live=false)
- boodah
  - [logs](https://app.datadoghq.com/logs?query=service%3Aboodah%20version%3Arti-15693-1%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1716204900000&to_ts=1716208020000&live=false)
  - [dashboard](https://app.datadoghq.com/dashboard/4bm-ca6-4kn/rtb-diagnostic-board?fromUser=true&refresh_mode=paused&tpl_var_control%5B0%5D=rti-15693-1-ctrl&tpl_var_target%5B0%5D=rti-15693-1&view=spans&from_ts=1716204900000&to_ts=1716208020000&live=false)